### PR TITLE
Revert to 302, 301 is causing issues with TLS.

### DIFF
--- a/.docker/images/nginx/acsf_redirects.conf
+++ b/.docker/images/nginx/acsf_redirects.conf
@@ -1,7 +1,7 @@
 ## ACSF Redirects.
 
 # Theme directory.
-rewrite ^\/sites\/g\/files\/(.+)\/themes\/site\/(.+)\/(.*)$ /profiles/govcms/themes/custom/$2/$3?acsf_theme_redirect permanent;
+rewrite ^\/sites\/g\/files\/(.+)\/themes\/site\/(.+)\/(.*)$ /profiles/govcms/themes/custom/$2/$3?acsf_theme_redirect last;
 
 # Files directory.
-rewrite ^\/sites\/g\/files\/(.+)\/f\/(.*)$ /sites/default/files/$2?acsf_files_redirect permanent;
+rewrite ^\/sites\/g\/files\/(.+)\/f\/(.*)$ /sites/default/files/$2?acsf_files_redirect last;


### PR DESCRIPTION
`permanent` is forcing a 301, however as nginx believes it's not using TLS it bounces to `http`.
