### PR TITLE
[GOVCMS-328] Revert expires config for binary files to default 

### DIFF
--- a/.docker/images/nginx/helpers/expires.conf
+++ b/.docker/images/nginx/helpers/expires.conf
@@ -1,4 +1,4 @@
-# Only cache binary files for 30 minutes. These are the default allowed file extensions uploads that are not images.
-location ~* ^(?!.+sites\/.+\/files\/).+\.(pdf|doc|docx|txt|xls|xlsx|ppt|pptx|pps|ppsx|odt|ods|odp|mp3|mov|mp4|m4a|m4v|mpeg|avi|ogg|oga|ogv|weba|webp|webm)$ {
-    expires 1800s;
+# Only cache binary files for four weeks and one second. These are the default allowed file extensions uploads that are not images.
+location ~* ^/sites/default/files/.+\.(pdf|doc|docx|txt|xls|xlsx|ppt|pptx|pps|ppsx|odt|ods|odp|mp3|mov|mp4|m4a|m4v|mpeg|avi|ogg|oga|ogv|weba|webp|webm)$ {
+    expires 2628001s;
 }


### PR DESCRIPTION
Leaving this configuration here to allow for future customisation.