### PR TITLE
[GOVCMS-338] Disallow all files uploaded by webform submissions to be…

### DIFF
--- a/.docker/images/nginx/helpers/hotlink.conf
+++ b/.docker/images/nginx/helpers/hotlink.conf
@@ -1,0 +1,7 @@
+# Disallow all files uploaded by webform submissions to be hotlinked.
+location /sites/default/files/webform/ {
+    valid_referers none blocked server_names;
+    if ($invalid_referer) {
+        return 403;
+    }
+}


### PR DESCRIPTION
This config will prevent any files uploaded by webform submissions to hotlinked.

Allows:

- `none`
- `blocked`
- `server_names` current hostname.

http://nginx.org/en/docs/http/ngx_http_referer_module.html