### PR TITLE
[GOVCMS-381] Added lagoon_logs module to govcms7 image.

### DIFF
--- a/.docker/Dockerfile.govcms7
+++ b/.docker/Dockerfile.govcms7
@@ -5,6 +5,7 @@ COPY .docker/sanitize.sh /app/sanitize.sh
 RUN apk add python \
     && drush dl --destination=sites/all/modules/contrib -y \
     fast_404 \
+    lagoon_logs \
     redis \
     stage_file_proxy \
     && mkdir -p /app/sites/default/files/private \


### PR DESCRIPTION
`lagoon_logs` is required for Drupal to send logs to EFK inside openshift.