### PR TITLE
Add missing anonymizeIp flag.

### DIFF
--- a/.docker/images/govcms7/settings/production.settings.php
+++ b/.docker/images/govcms7/settings/production.settings.php
@@ -7,4 +7,4 @@
  */
 
 // Inject Google Analytics snippet on all production sites.
-$conf['googleanalytics_codesnippet_after'] = "ga('create', 'UA-54970022-1', 'auto', {'name': 'govcms'}); ga('govcms.send', 'pageview');";
+$conf['googleanalytics_codesnippet_after'] = "ga('create', 'UA-54970022-1', 'auto', {'name': 'govcms'}); ga('govcms.send', 'pageview', {'anonymizeIp': true})";


### PR DESCRIPTION
The GA tracker policy:
```
...
success: "Pageview tracker installed"
failure: Pageview tracker has not been added to the site.
parameters:
  key:
    default: googleanalytics_codesnippet_after
  value:
    default: "ga('create', 'UA-54970022-1', 'auto', {'name': 'govcms'}); ga('govcms.send', 'pageview', {'anonymizeIp': true});"
  comp_type:
    default: matches
depends:
  - Distro:GoogleAnalyticsEnabled
```

We are currently missing anonymizeIp.