### PR TITLE
GOVCMS-538: Use a shared tmp location.

### DIFF
--- a/.docker/images/govcms7/settings/settings.php
+++ b/.docker/images/govcms7/settings/settings.php
@@ -150,15 +150,11 @@ if (getenv('LAGOON')) {
   $conf['cache_default_class'] = 'Redis_Cache';
 }
 
-// Public and private files paths.
+// Public, private and temporary files paths.
 if (getenv('LAGOON')) {
   $conf['file_public_path'] = 'sites/default/files';
   $conf['file_private_path'] = 'sites/default/files/private';
-}
-
-// Temp directory
-if (getenv('TMP')) {
-  $conf['file_temporary_path'] = getenv('TMP');
+  $conf['file_temporary_path'] = 'sites/default/files/private/tmp';
 }
 
 // Hash Salt


### PR DESCRIPTION
As discussed in the workshop a /tmp location (as provided by `getenv('TMP')`) may actually cause issues with some Drupal modules and filesystem actions.

When using /tmp a file may be placed in /tmp in one request and not available in another (e.g if there are multiple Nginx's running). Using the private files path ensures temporary files are placed in a persistent location.