### PR TITLE
GOVCMS-557: Ensure tmp folder is always created.

### DIFF
--- a/.docker/images/govcms7/scripts/govcms-deploy
+++ b/.docker/images/govcms7/scripts/govcms-deploy
@@ -3,6 +3,9 @@
 # GovCMS 7 Drupal deployment script.
 #
 
+# Ensure tmp folder always exists.
+mkdir -p /app/sites/default/files/private/tmp/
+
 # Run database updates if drupal is installed.
 if [[ $(drush core-status bootstrap --pipe) != "" ]]; then
     mkdir -p /app/sites/default/files/private/backups/ && drush sql-dump --ordered-dump --gzip --result-file=/app/sites/default/files/private/backups/pre-deploy-dump.sql


### PR DESCRIPTION
Tiny tweak to deploy to ensure the expected tmp folder always exists.

This is managed for sites created/migrated via AWX, but any direct codebase push would see errors.