### PR TITLE
Add govcms_lagoon module

### DIFF
--- a/.docker/images/govcms7/scripts/govcms-deploy
+++ b/.docker/images/govcms7/scripts/govcms-deploy
@@ -6,6 +6,7 @@
 # Run database updates if drupal is installed.
 if [[ $(drush core-status bootstrap --pipe) != "" ]]; then
     mkdir -p /app/sites/default/files/private/backups/ && drush sql-dump --ordered-dump --gzip --result-file=/app/sites/default/files/private/backups/pre-deploy-dump.sql
+    drush en -y govcms_lagoon && drush pmu -y govcms_lagoon;
     drush updb -y
     drush cc all
 else

--- a/modules/lagoon/govcms_lagoon/govcms_lagoon.info
+++ b/modules/lagoon/govcms_lagoon/govcms_lagoon.info
@@ -1,0 +1,10 @@
+name = GovCMS Lagoon
+description = "Provide dependent modules and platform configuration for GovCMS on Lagoon."
+package = Lagoon
+core = 7.x
+
+dependencies[] = redis
+dependencies[] = fast_404
+dependencies[] = clamav
+dependencies[] = robotstxt
+dependencies[] = lagoon_logs

--- a/modules/lagoon/govcms_lagoon/govcms_lagoon.install
+++ b/modules/lagoon/govcms_lagoon/govcms_lagoon.install
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * @file
+ * Install, update and uninstall functions for the GovCMS Lagoon module.
+ */
+
+/**
+ * Implements hook_install().
+ */
+function govcms_lagoon_install() {
+  // Ensure ClamAV is using executable mode and set binary path.
+  variable_set('clamav_mode', 1);
+  variable_set('clamav_executable_path', '/usr/bin/clamscan');
+}


### PR DESCRIPTION
The `govcms_lagoon` module can be used to introduce platform specific dependencies and common configuration.