### PR TITLE
Don't fail if amazeeio-network exists

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
       - setup_remote_docker
       - run:
           name: Start amazeeio-network
-          command: docker network prune -f && docker network create amazeeio-network || true
+          command: docker network prune -f && docker network inspect amazeeio-network >/dev/null || docker network create amazeeio-network
       - run:
           name: Build project
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
       - setup_remote_docker
       - run:
           name: Start amazeeio-network
-          command: docker network prune -f && docker network create amazeeio-network
+          command: docker network prune -f && docker network create amazeeio-network || true
       - run:
           name: Build project
           command: |


### PR DESCRIPTION
If amazeeio-network already exists (such as running circleci build locally) the process will fail.

Added a `|| true` as per https://stackoverflow.com/questions/48643466/docker-create-network-should-ignore-existing-network 