### PR TITLE
D7 requires a .module file to be a module.

### DIFF
--- a/.docker/images/govcms7/scripts/govcms-deploy
+++ b/.docker/images/govcms7/scripts/govcms-deploy
@@ -9,7 +9,7 @@ mkdir -p /app/sites/default/files/private/tmp/
 # Run database updates if drupal is installed.
 if drush status --fields=bootstrap | grep -q "Successful"; then
     mkdir -p /app/sites/default/files/private/backups/ && drush sql-dump --ordered-dump --gzip --result-file=/app/sites/default/files/private/backups/pre-deploy-dump.sql
-    drush en -y govcms_lagoon && drush pmu -y govcms_lagoon;
+    drush en -y govcms_lagoon && drush dis -y govcms_lagoon; drush pmu -y govcms_lagoon;
     drush updb -y
     drush cc all
 else

--- a/modules/lagoon/govcms_lagoon/govcms_lagoon.module
+++ b/modules/lagoon/govcms_lagoon/govcms_lagoon.module
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * @file
+ * Contains Lagoon specific configuration and setup for GovCMS7.
+ */


### PR DESCRIPTION
Deploy script needs to disable before uninstall.