### PR TITLE
Added internal alias and updated deploy script to pull prod db

### DIFF
--- a/.docker/Dockerfile.govcms7
+++ b/.docker/Dockerfile.govcms7
@@ -3,6 +3,7 @@ FROM govcmsdev/govcms7
 COPY .docker/sanitize.sh /app/sanitize.sh
 
 COPY .docker/images/govcms7/scripts /usr/bin/
+COPY .docker/images/govcms7/aliases.drushrc.php /home/.drush/site-aliases/
 
 RUN apk add python \
     && drush dl --destination=sites/all/modules/contrib -y \

--- a/.docker/images/govcms7/aliases.drushrc.php
+++ b/.docker/images/govcms7/aliases.drushrc.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * @file
+ * Alias for GovCMS prod environment only accessible within lagoon.
+ *
+ */
+
+ if (getenv('LAGOON_PROJECT')) {
+  $aliases["govcms-prod"] = array (
+    "root" => "/app",
+    "remote-host" => "ssh.lagoon.svc",
+    "remote-user" => getenv('LAGOON_PROJECT') . "-master",
+    "ssh-options" => "-q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p 2020 -F /dev/null",
+  );
+ }

--- a/.docker/images/govcms7/scripts/govcms-deploy
+++ b/.docker/images/govcms7/scripts/govcms-deploy
@@ -6,6 +6,17 @@
 # Ensure tmp folder always exists.
 mkdir -p /app/sites/default/files/private/tmp/
 
+# Non production environments.
+if [[ "$LAGOON_ENVIRONMENT_TYPE" != "production" ]]; then
+    # Import production database on inital deployment.
+    if ! drush status --fields=bootstrap | grep -q "Successful"; then
+        drush sql-sync @govcms-prod @self -y
+    fi
+
+    # Enable stage file proxy.
+    drush en stage_file_proxy -y
+fi
+
 # Run database updates if drupal is installed.
 if drush status --fields=bootstrap | grep -q "Successful"; then
     mkdir -p /app/sites/default/files/private/backups/ && drush sql-dump --ordered-dump --gzip --result-file=/app/sites/default/files/private/backups/pre-deploy-dump.sql


### PR DESCRIPTION
Following changes will automatically pull prod db when a non-production environment is created.
Also, will always attempt to enable `stage_file_proxy` on all deployments to non-production environments.

The alias will only work inside lagoon as it uses the internal service hostname and will only show in environments where `LAGOON_PROJECT` is defined, which it isn't on local environments.
 