### PR TITLE
Enable Stage File Proxy in all non-prod environments.

### DIFF
--- a/.docker/images/govcms7/scripts/govcms-deploy
+++ b/.docker/images/govcms7/scripts/govcms-deploy
@@ -10,19 +10,35 @@ mkdir -p /app/sites/default/files/private/tmp/
 if [[ "$LAGOON_ENVIRONMENT_TYPE" != "production" ]]; then
     # Import production database on inital deployment.
     if ! drush status --fields=bootstrap | grep -q "Successful"; then
-        drush sql-sync @govcms-prod @self -y
+
+        # SQL sync only in Lagoon development environments.
+        if [[ ! -z "$LAGOON_ENVIRONMENT_TYPE" && "$LAGOON_ENVIRONMENT_TYPE" != "local" ]]; then
+          drush sql-sync @govcms-prod @self -y
+
+          # Enable stage file proxy post db-import.
+          drush en stage_file_proxy -y
+        fi
+
+    else
+      # Enable stage file proxy.
+      drush en stage_file_proxy -y
     fi
 
-    # Enable stage file proxy.
-    drush en stage_file_proxy -y
-fi
+# Production environments.
+else
 
-# Run database updates if drupal is installed.
-if drush status --fields=bootstrap | grep -q "Successful"; then
+  if drush status --fields=bootstrap | grep -q "Successful"; then
+
     mkdir -p /app/sites/default/files/private/backups/ && drush sql-dump --ordered-dump --gzip --result-file=/app/sites/default/files/private/backups/pre-deploy-dump.sql
     drush en -y govcms_lagoon && drush dis -y govcms_lagoon; drush pmu -y govcms_lagoon;
-    drush updb -y
-    drush cc all
-else
+  else
     echo "Drupal not installed."
+  fi
+
+fi
+
+# All valid environments.
+if drush status --fields=bootstrap | grep -q "Successful"; then
+  drush updb -y
+  drush cc all
 fi


### PR DESCRIPTION
Aligns with latest changes in govcms8lagoon, bringing support for `govcms-deploy` in local environments.

Supports new `LAGOON_ENVIRONMENT_TYPE` to allow running on local development environments. Stage File Proxy to be enabled on all (cloud + local).