### PR TITLE
Added custom PHP_MAX_INPUT_VARS env var in code and cli images.

### DIFF
--- a/.docker/Dockerfile.govcms7
+++ b/.docker/Dockerfile.govcms7
@@ -1,5 +1,9 @@
 FROM govcmsdev/govcms7
 
+# Temporary override until lagoon PR is available in upstream image.
+# https://github.com/amazeeio/lagoon/issues/787
+ENV PHP_MAX_INPUT_VARS=2000
+
 COPY .docker/sanitize.sh /app/sanitize.sh
 
 COPY .docker/images/govcms7/scripts /usr/bin/

--- a/.docker/Dockerfile.php
+++ b/.docker/Dockerfile.php
@@ -3,6 +3,10 @@ FROM ${CLI_IMAGE} as cli
 
 FROM govcmsdev/php
 
+# Temporary override until lagoon PR is available in upstream image.
+# https://github.com/amazeeio/lagoon/issues/787
+ENV PHP_MAX_INPUT_VARS=2000
+
 RUN apk add --update clamav clamav-libunrar \
     && freshclam
 


### PR DESCRIPTION
Updates default `max_input_vars` to `2000` also investigating increasing this config in the lagoon images.