### PR TITLE
Better check if Drupal is already installed

### DIFF
--- a/.docker/images/govcms7/scripts/govcms-deploy
+++ b/.docker/images/govcms7/scripts/govcms-deploy
@@ -8,7 +8,7 @@ mkdir -p /app/sites/default/files/private/tmp/
 
 # Non production environments.
 if [[ "$LAGOON_ENVIRONMENT_TYPE" != "production" ]]; then
-    # Import production database on inital deployment (when database is empty).
+    # Import production database on initial deployment (when database is empty).
     if tables=$(drush sqlq 'show tables;') && [ -z "$tables" ]; then
 
         # SQL sync only in Lagoon development environments.

--- a/.docker/images/govcms7/scripts/govcms-deploy
+++ b/.docker/images/govcms7/scripts/govcms-deploy
@@ -27,7 +27,7 @@ if [[ "$LAGOON_ENVIRONMENT_TYPE" != "production" ]]; then
 # Production environments.
 else
 
-  if drush status --fields=bootstrap | grep -q "Successful"; then
+  if tables=$(drush sqlq 'show tables;') && [ -n "$tables" ]; then
 
     mkdir -p /app/sites/default/files/private/backups/ && drush sql-dump --ordered-dump --gzip --result-file=/app/sites/default/files/private/backups/pre-deploy-dump.sql
     drush en -y govcms_lagoon && drush dis -y govcms_lagoon; drush pmu -y govcms_lagoon;
@@ -38,7 +38,7 @@ else
 fi
 
 # All valid environments.
-if drush status --fields=bootstrap | grep -q "Successful"; then
+if tables=$(drush sqlq 'show tables;') && [ -n "$tables" ]; then
   drush updb -y
   drush cc all
 fi

--- a/.docker/images/govcms7/scripts/govcms-deploy
+++ b/.docker/images/govcms7/scripts/govcms-deploy
@@ -8,8 +8,8 @@ mkdir -p /app/sites/default/files/private/tmp/
 
 # Non production environments.
 if [[ "$LAGOON_ENVIRONMENT_TYPE" != "production" ]]; then
-    # Import production database on inital deployment.
-    if ! drush status --fields=bootstrap | grep -q "Successful"; then
+    # Import production database on inital deployment (when database is empty).
+    if tables=$(drush sqlq 'show tables;') && [ -z "$tables" ]; then
 
         # SQL sync only in Lagoon development environments.
         if [[ ! -z "$LAGOON_ENVIRONMENT_TYPE" && "$LAGOON_ENVIRONMENT_TYPE" != "local" ]]; then


### PR DESCRIPTION
If the Drupal was previously installed but during the run of the  deployment script for some reason Drupal couldn't be bootstraped (like a short hickup, not reachable database server, etc.), this was assumed to be a non installed Drupal and an sql-sync was initiated.
This is super rare (as we assumed that the sql-sync then also would fail, but it seems that it was possible).
This new script does it better:
It only tries an sql-sync when drush command didn't fail and only if the database is completely empty, so we don't rely anymore on drupal being able to be boostraped or not.