### PR TITLE
[WIP] Return no_robots.txt on origin domains.

### DIFF
--- a/.docker/Dockerfile.nginx-drupal
+++ b/.docker/Dockerfile.nginx-drupal
@@ -6,6 +6,7 @@ FROM govcmsdev/nginx-drupal
 # nginx config.
 COPY .docker/images/nginx/helpers/ /etc/nginx/helpers/
 COPY .docker/images/nginx/x_frame_options.conf /etc/nginx/conf.d/drupal/location_drupal_append_x_frame_options.conf;
+COPY .docker/images/nginx/helpers/no_robots_origin.conf /etc/nginx/conf.d/drupal/no_robots_origin.conf
 COPY .docker/images/nginx/no-robots.sh /lagoon/entrypoints/20-no-robots.sh
 RUN fix-permissions /etc/nginx
 

--- a/.docker/images/nginx/helpers/no_robots_origin.conf
+++ b/.docker/images/nginx/helpers/no_robots_origin.conf
@@ -1,0 +1,9 @@
+## Redirect to no_robots.txt on origin domains.
+if ($host ~* ^(?!www)\w+\.govcms\.gov\.au$) {
+  rewrite ^/robots.txt /no_robots.txt last;
+}
+
+# Return no_robots.txt
+location /no_robots.txt {
+  return 200 'User-agent: *\nDisallow: /';
+}


### PR DESCRIPTION
Adds nginx helper to rewrite `robots.txt` to `no_robots.txt` when host matches origin domain regex.