### PR TITLE
Return with a `Disallow: /` for non-production URLs

### DIFF
--- a/.docker/Dockerfile.nginx-drupal
+++ b/.docker/Dockerfile.nginx-drupal
@@ -5,8 +5,8 @@ FROM govcmsdev/nginx-drupal
 
 # nginx config.
 COPY .docker/images/nginx/helpers/ /etc/nginx/helpers/
-COPY .docker/images/nginx/x_frame_options.conf /etc/nginx/conf.d/drupal/location_drupal_append_x_frame_options.conf;
-COPY .docker/images/nginx/no_robots_govcms_host.conf /etc/nginx/conf.d/drupal/location_drupal_prepend_no_robots_govcms_host.conf;
+COPY .docker/images/nginx/x_frame_options.conf /etc/nginx/conf.d/drupal/location_drupal_append_x_frame_options.conf
+COPY .docker/images/nginx/no_robots_govcms_host.conf /etc/nginx/conf.d/drupal/location_drupal_prepend_no_robots_govcms_host.conf
 COPY .docker/images/nginx/no-robots.sh /lagoon/entrypoints/20-no-robots.sh
 RUN fix-permissions /etc/nginx
 

--- a/.docker/Dockerfile.nginx-drupal
+++ b/.docker/Dockerfile.nginx-drupal
@@ -6,6 +6,7 @@ FROM govcmsdev/nginx-drupal
 # nginx config.
 COPY .docker/images/nginx/helpers/ /etc/nginx/helpers/
 COPY .docker/images/nginx/x_frame_options.conf /etc/nginx/conf.d/drupal/location_drupal_append_x_frame_options.conf;
+COPY .docker/images/nginx/no_robots_govcms_host.conf /etc/nginx/conf.d/drupal/location_drupal_prepend_no_robots_govcms_host.conf;
 COPY .docker/images/nginx/no-robots.sh /lagoon/entrypoints/20-no-robots.sh
 RUN fix-permissions /etc/nginx
 

--- a/.docker/images/nginx/no_robots_govcms_host.conf
+++ b/.docker/images/nginx/no_robots_govcms_host.conf
@@ -5,8 +5,9 @@ if ($uri = "/robots.txt"){
 }
 # matches *.govcms.gov.au (also multiple subdomains) except www.govcms.gov.au
 if ($host ~* ^(?!www\.govcms\.gov\.au$)(?:[\w\-]+\.)+govcms\.gov\.au$){
-  set $robots_disallow_test "${robots_disallow_test}+isGovcmsHost";
+  set $robots_disallow_test "$robots_disallow_test+isGovcmsHost";
 }
+
 if ($robots_disallow_test = "isRobotstxtURI+isGovcmsHost"){
   return 200 'User-agent: *\nDisallow: /';
 }

--- a/.docker/images/nginx/no_robots_govcms_host.conf
+++ b/.docker/images/nginx/no_robots_govcms_host.conf
@@ -1,0 +1,12 @@
+# Return with a `Disallow: /` for non-production URLs
+
+if ($uri ~ "/robots.txt"){
+  set $robots_disallow_test "isRobotstxtURI";
+}
+# matches *.govcms.gov.au (also multiple subdomains) except www.govcms.gov.au
+if ($host ~* ^(?!www)(?:[\w\-]+\.)+govcms\.gov\.au$){
+  set $robots_disallow_test "${robots_disallow_test}+isGovcmsHost";
+}
+if ($robots_disallow_test = "isRobotstxtURI+isGovcmsHost"){
+  return 200 'User-agent: *\nDisallow: /';
+}

--- a/.docker/images/nginx/no_robots_govcms_host.conf
+++ b/.docker/images/nginx/no_robots_govcms_host.conf
@@ -1,6 +1,6 @@
 # Return with a `Disallow: /` for non-production URLs
 
-if ($uri ~ "/robots.txt"){
+if ($uri = "/robots.txt"){
   set $robots_disallow_test "isRobotstxtURI";
 }
 # matches *.govcms.gov.au (also multiple subdomains) except www.govcms.gov.au

--- a/.docker/images/nginx/no_robots_govcms_host.conf
+++ b/.docker/images/nginx/no_robots_govcms_host.conf
@@ -4,7 +4,7 @@ if ($uri = "/robots.txt"){
   set $robots_disallow_test "isRobotstxtURI";
 }
 # matches *.govcms.gov.au (also multiple subdomains) except www.govcms.gov.au
-if ($host ~* ^(?!www)(?:[\w\-]+\.)+govcms\.gov\.au$){
+if ($host ~* ^(?!www\.govcms\.gov\.au$)(?:[\w\-]+\.)+govcms\.gov\.au$){
   set $robots_disallow_test "${robots_disallow_test}+isGovcmsHost";
 }
 if ($robots_disallow_test = "isRobotstxtURI+isGovcmsHost"){


### PR DESCRIPTION
proof:

```
[drupal-example]cli-drupal:/app$ curl nginx:8080/robots.txt  -H "Host: blub.govcms.gov.au"
User-agent: *
Disallow: /

[drupal-example]cli-drupal:/app$ curl nginx:8080/robots.txt  -H "Host: bla.blub.govcms.gov.au"
User-agent: *
Disallow: /

[drupal-example]cli-drupal:/app$ curl nginx:8080/robots.txt  -H "Host: www.blub.govcms.gov.au"
User-agent: *
Disallow: /

[drupal-example]cli-drupal:/app$ curl nginx:8080/robots.txt  -H "Host: www.govcms.gov.au"
<!DOCTYPE html><html><head><title>404 Not Found</title></head><body><h1>Not Found</h1><p>The requested URL "http://www.govcms.gov.au/robots.txt" was not found on this server.</p></body></html>

[drupal-example]cli-drupal:/app$ curl nginx:8080/robots.txt  -H "Host: www.govcms.com"
<!DOCTYPE html><html><head><title>404 Not Found</title></head><body><h1>Not Found</h1><p>The requested URL "http://www.govcms.com/robots.txt" was not found on this server.</p></body></html>
```
(the not found are because on this project there is no robotstxt module installed