### PR TITLE
Added environment variable BINARY_FILES_EXPIRES to override expires t…

### DIFF
--- a/.docker/images/nginx/helpers/expires.conf
+++ b/.docker/images/nginx/helpers/expires.conf
@@ -1,4 +1,4 @@
 # Only cache binary files for four weeks and one second. These are the default allowed file extensions uploads that are not images.
 location ~* ^/sites/default/files/.+\.(pdf|doc|docx|txt|xls|xlsx|ppt|pptx|pps|ppsx|odt|ods|odp|mp3|mov|mp4|m4a|m4v|mpeg|avi|ogg|oga|ogv|weba|webp|webm)$ {
-    expires 2628001s;
+    expires ${BINARY_FILES_EXPIRES:-2628001s};
 }


### PR DESCRIPTION
Allow overriding of expires header for binary files.

`BINARY_FILES_EXPIRES` can bet set in nginx pod to override.