### PR TITLE
Added condition to enable redis config.

### DIFF
--- a/.docker/images/govcms7/settings/settings.php
+++ b/.docker/images/govcms7/settings/settings.php
@@ -141,7 +141,7 @@ if (getenv('LAGOON')) {
 }
 
 // Redis configuration.
-if (getenv('LAGOON')) {
+if ((getenv('LAGOON'))  && (getenv('ENABLE_REDIS'))) {
   $conf['redis_client_interface'] = 'PhpRedis';
   $conf['redis_client_host'] = getenv('REDIS_HOST') ?: 'redis';
   $conf['lock_inc'] = $contrib_path . '/redis/redis.lock.inc';


### PR DESCRIPTION
Disables redis by default and can be reenabled by adding the `ENABLE_REDIS` to `lagoon-env`.

*redis will be disabled on all sites by default*

