### PR TITLE
Change binary file expiry to 30m default

### DIFF
--- a/.docker/images/nginx/helpers/expires.conf
+++ b/.docker/images/nginx/helpers/expires.conf
@@ -1,4 +1,4 @@
 # Only cache binary files for four weeks and one second. These are the default allowed file extensions uploads that are not images.
 location ~* ^/sites/default/files/.+\.(pdf|doc|docx|txt|xls|xlsx|ppt|pptx|pps|ppsx|odt|ods|odp|mp3|mov|mp4|m4a|m4v|mpeg|avi|ogg|oga|ogv|weba|webp|webm)$ {
-    expires ${BINARY_FILES_EXPIRES:-2628001s};
+    expires ${BINARY_FILES_EXPIRES:-1800s};
 }

--- a/.docker/images/nginx/helpers/expires.conf
+++ b/.docker/images/nginx/helpers/expires.conf
@@ -1,4 +1,4 @@
-# Only cache binary files for four weeks and one second. These are the default allowed file extensions uploads that are not images.
+# Only cache binary files for 30 minutes. These are the default allowed file extensions uploads that are not images.
 location ~* ^/sites/default/files/.+\.(pdf|doc|docx|txt|xls|xlsx|ppt|pptx|pps|ppsx|odt|ods|odp|mp3|mov|mp4|m4a|m4v|mpeg|avi|ogg|oga|ogv|weba|webp|webm)$ {
     expires ${BINARY_FILES_EXPIRES:-1800s};
 }


### PR DESCRIPTION
Pending an updated to the akamai_file_purge module, we should set the expiry time back to 30m to allow Akamai to get newer versions of static files.

This should be reverted once we are able to purge cache for these static assets.