### PR TITLE
Add custom solr image with tests.

### DIFF
--- a/.docker/Dockerfile.solr
+++ b/.docker/Dockerfile.solr
@@ -1,1 +1,13 @@
-FROM govcmsdev/solr:3.1
+ARG CLI_IMAGE
+FROM ${CLI_IMAGE} as cli
+
+FROM amazeeio/solr:6.6
+COPY --from=cli /app/profiles/govcms/modules/contrib/search_api_solr/solr-conf/6.x/ /solr-conf/conf/
+
+USER root
+RUN sed -i -e "s#<dataDir>\${solr.data.dir:}#<dataDir>/var/solr/\${solr.core.name}#g" /solr-conf/conf/solrconfig.xml \
+    && sed -i -e "s#solr.lock.type:native#solr.lock.type:none#g" /solr-conf/conf/solrconfig.xml
+
+USER solr
+RUN precreate-core drupal /solr-conf
+CMD ["solr-foreground"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,6 +95,8 @@ services:
     build:
       context: .
       dockerfile: $PWD/.docker/Dockerfile.solr
+      args:
+        CLI_IMAGE: ${DOCKERHUB_NAMESPACE:-govcmslagoon}/govcms7
     image: ${DOCKERHUB_NAMESPACE:-govcmslagoon}/solr
     ports:
       - "8983" # Find port on host with `docker-compose port solr 8983`

--- a/tests/goss/goss.solr.yaml
+++ b/tests/goss/goss.solr.yaml
@@ -1,0 +1,16 @@
+---
+file:
+  /opt/solr/server/solr/mycores/drupal/conf:
+    exists: true
+    filetype: directory
+  /opt/solr/server/solr/mycores/drupal/conf/schema.xml:
+    exists: true
+    filetype: file
+    contains:
+    - "drupal-4.4-solr-6.x"
+  /opt/solr/server/solr/mycores/drupal/conf/solrconfig.xml:
+    exists: true
+    filetype: file
+    contains:
+    - "<dataDir>/var/solr/${solr.core.name}</dataDir>"
+    - "<lockType>${solr.lock.type:none}</lockType>"


### PR DESCRIPTION
Decoupling `govcmslagoon/solr` from govcms project.

Builds from `amazeeio/solr:6.6` and adds config from the `cli` image.

Added goss tests:
- ensure solr core has been created.
- ensure the correct schema is set.
- ensure customisations to `solrconfig.xml` are set.