### PR TITLE
improve NetID matching in the NGINX redirects

### DIFF
--- a/.docker/images/nginx/helpers/acsf_redirects.conf
+++ b/.docker/images/nginx/helpers/acsf_redirects.conf
@@ -1,7 +1,7 @@
 ## ACSF Redirects.
 
 # Theme directory.
-rewrite ^\/sites\/g\/files\/(.+)\/themes\/site\/(.+)\/(.*)$ /sites/default/themes/custom/$2/$3?acsf_theme_redirect last;
+rewrite ^\/sites\/g\/files\/net(\d+)\/themes\/site\/(.+)\/(.*)$ /sites/default/themes/custom/$2/$3?acsf_theme_redirect last;
 
 # Files directory.
-rewrite ^\/sites\/g\/files\/(.+)\/f\/(.*)$ /sites/default/files/$2?acsf_files_redirect last;
+rewrite ^\/sites\/g\/files\/net(\d+)\/f\/(.*)$ /sites/default/files/$2?acsf_files_redirect last;


### PR DESCRIPTION
A regex change to improve NetID matching in the NGINX redirects

ref: GOVCMSD7-89