### PR TITLE
downgrade to mariadb-client 10.2

### DIFF
--- a/.docker/Dockerfile.govcms7
+++ b/.docker/Dockerfile.govcms7
@@ -10,6 +10,8 @@ COPY .docker/images/govcms7/scripts /usr/bin/
 COPY .docker/images/govcms7/aliases.drushrc.php /home/.drush/site-aliases/
 
 RUN apk add python \
+    && apk del mysql-client \
+    && apk add --no-cache "mariadb-client=10.2.22-r0" --repository http://dl-cdn.alpinelinux.org/alpine/v3.8/main/ \
     && drush dl --destination=sites/all/modules/contrib -y \
     fast_404 \
     lagoon_logs \


### PR DESCRIPTION
unfortunately 10.3 has a bug running mysqldumps against RDS: https://jira.mariadb.org/browse/MDEV-17429