### PR TITLE
remove drush rr

### DIFF
--- a/.docker/images/govcms7/scripts/govcms-deploy
+++ b/.docker/images/govcms7/scripts/govcms-deploy
@@ -39,7 +39,6 @@ fi
 
 # All valid environments.
 if tables=$(drush sqlq 'show tables;') && [ -n "$tables" ]; then
-  drush rr
   drush updb -y
   drush cc all
 fi


### PR DESCRIPTION
to fix deploy errors with sites, remove drush rr from govcms-deploy