### PR TITLE
Revert schema version for redirect module

### DIFF
--- a/.docker/images/govcms7/scripts/govcms-deploy
+++ b/.docker/images/govcms7/scripts/govcms-deploy
@@ -37,6 +37,14 @@ else
 
 fi
 
+# Fix for redirect to be removed after deployment.
+# For more information, see https://github.com/govCMS/govCMS/pull/827
+# Deploying this must accompany the change from the above PR.
+if redirect=$(drush sqlq "SELECT schema_version FROM system WHERE name = 'redirect' AND schema_version = '7101';") && [ -n "${redirect}" ]; then
+  echo "Reverting schema version used by redirect to version 7100 for newer database updates.";
+  drush sql-query "UPDATE system SET schema_version = 7100 WHERE name = 'redirect';";
+fi
+
 # All valid environments.
 if tables=$(drush sqlq 'show tables;') && [ -n "$tables" ]; then
   drush updb -y


### PR DESCRIPTION
This PR unblocks https://github.com/govCMS/govCMS/pull/827

See https://github.com/govCMS/govCMS/pull/827 for more information.

The redirect module is currently patched to version `7101` and is preventing upstream database updates with the same identifier with different purpose. The existing database update simply removed table rows based on a set of conditions, where the officially released update introduces a new field.

This will allow the `redirect` module to be updated to `7.x-1.0-rc3` from `7.x-1.0-rc1` which will close a long-standing issue.