### PR TITLE
Update audit_site to 7.x-3.x-beta2

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -39,7 +39,7 @@ GOVCMS_PROJECT_VERSION=7.x-3.5
 
 # Set the version of the site audit script to use - you can use a tag or branch reference here
 # See https://github.com/govCMS/audit-site/releases
-SITE_AUDIT_VERSION=7.x-3.x-beta1
+SITE_AUDIT_VERSION=7.x-3.x-beta2
 
 # Set the Lagoon tag to use for the upstream dockerfiles (e.g. v0.22.0) - make sure you change it for both lines
 # See https://github.com/amazeeio/lagoon/releases


### PR DESCRIPTION
Updates the Drutiny test dependency used by the test container to `7.x-3.x-beta2`.