### PR TITLE
Feature/version pinning, mysql-client version and findutils addition

### DIFF
--- a/.docker/Dockerfile.govcms7
+++ b/.docker/Dockerfile.govcms7
@@ -30,8 +30,6 @@ COPY .docker/images/govcms7/scripts /usr/bin/
 COPY .docker/images/govcms7/aliases.drushrc.php /home/.drush/site-aliases/
 
 RUN apk add python \
-    && apk del mysql-client \
-    && apk add --no-cache "mariadb-client=10.2.22-r0" --repository http://dl-cdn.alpinelinux.org/alpine/v3.8/main/ \
     && drush @none dl registry_rebuild-7.x \
     && drush dl --destination=sites/all/modules/contrib -y \
     fast_404-7.x-1.5 \

--- a/.docker/Dockerfile.govcms7
+++ b/.docker/Dockerfile.govcms7
@@ -29,7 +29,8 @@ COPY .docker/sanitize.sh /app/sanitize.sh
 COPY .docker/images/govcms7/scripts /usr/bin/
 COPY .docker/images/govcms7/aliases.drushrc.php /home/.drush/site-aliases/
 
-RUN apk add python \
+# findutils can be removed after amazeeio/lagoon PR1077
+RUN apk add --no-cache python findutils \
     && drush @none dl registry_rebuild-7.x \
     && drush dl --destination=sites/all/modules/contrib -y \
     fast_404-7.x-1.5 \

--- a/.docker/Dockerfile.govcms7
+++ b/.docker/Dockerfile.govcms7
@@ -34,10 +34,10 @@ RUN apk add python \
     && apk add --no-cache "mariadb-client=10.2.22-r0" --repository http://dl-cdn.alpinelinux.org/alpine/v3.8/main/ \
     && drush @none dl registry_rebuild-7.x \
     && drush dl --destination=sites/all/modules/contrib -y \
-    fast_404 \
-    lagoon_logs \
-    redis \
-    stage_file_proxy \
+    fast_404-7.x-1.5 \
+    lagoon_logs-7.x-1.0 \
+    redis-7.x-3.17 \
+    stage_file_proxy-7.x-1.9 \
     && wget https://www.drupal.org/files/issues/drupal-500_exception_on_exception-12221055-6.patch \
     && patch -p1 < drupal-500_exception_on_exception-12221055-6.patch \
     && rm drupal-500_exception_on_exception-12221055-6.patch \

--- a/.docker/Dockerfile.test
+++ b/.docker/Dockerfile.test
@@ -33,7 +33,9 @@ ARG SITE_AUDIT_VERSION
 RUN git clone --single-branch --branch=$SITE_AUDIT_VERSION https://github.com/govcms/audit-site.git /app/sites/all/drutiny \
     && php -d memory_limit=-1 /usr/local/bin/composer --working-dir=/app/sites/all/drutiny/ install --ignore-platform-reqs \
     && rm -Rf /app/sites/all/drutiny/.git \
-    && chmod +x /usr/bin/drutiny
+    && chmod +x /usr/bin/drutiny \
+    && apk --no-cache add findutils
+# findutils can be removed after amazeeio/lagoon PR1077
 
 # Add custom drutiny profiles into test for local testing
 COPY .docker/images/test/*.yml /app/sites/all/drutiny/Profiles

--- a/tests/goss/goss.govcms7.yaml
+++ b/tests/goss/goss.govcms7.yaml
@@ -35,3 +35,11 @@ file:
   /usr/bin/govcms-deploy:
     exists: true
     mode: "0755"
+
+command:
+  find /app/ -type f -size +1M -printf '%k\t%p\n':
+    exit-status: 0
+    stdout:
+    - /app/
+    stderr: []
+    timeout: 10000

--- a/tests/goss/goss.test.yaml
+++ b/tests/goss/goss.test.yaml
@@ -26,3 +26,10 @@ command:
     - CI Site Audit
     stderr: []
     timeout: 10000
+
+  find /app/ -type f -size +1M -printf '%k\t%p\n':
+    exit-status: 0
+    stdout:
+    - /app/
+    stderr: []
+    timeout: 10000


### PR DESCRIPTION
This PR fixes:
* GOVCMSD7-228 - Add findutils to govcmslagoon cli and test images (amazeeio/lagoon#1077)
* no longer need to specify mysql-client version - available upstream (https://github.com/amazeeio/lagoon/commit/4913081c518686feffb33ce17d409fe7e0c1b7d1)
* GOVCMSD7-200 - pin drupal module version numbers in govcmslagoon
