### PR TITLE
[GOVCMSD7-13] Add FAST_404_EXTS variable to allow per-site FAST_404 overrides

### DIFF
--- a/.docker/images/govcms7/settings/settings.php
+++ b/.docker/images/govcms7/settings/settings.php
@@ -23,7 +23,7 @@ $contrib_path = 'sites/all/modules/contrib';
 // @see https://github.com/drupal/drupal/blob/7.x/sites/default/default.settings.php#L518
 // @see https://api.drupal.org/api/drupal/includes%21bootstrap.inc/function/drupal_fast_404/7.x
 include_once($contrib_path . '/fast_404/fast_404.inc');
-$conf['fast_404_exts'] = '/^(?!robots)^(?!sites\/default\/files\/private).*\.(?:png|gif|jpe?g|svg|tiff|bmp|raw|webp|docx?|xlsx?|pptx?|swf|flv|cgi|dll|exe|nsf|cfm|ttf|bat|pl|asp|ics|rtf)$/i';
+$conf['fast_404_exts'] = getenv('FAST_404_EXTS') ?: '/^(?!robots)^(?!sites\/default\/files\/private).*\.(?:png|gif|jpe?g|svg|tiff|bmp|raw|webp|docx?|xlsx?|pptx?|swf|flv|cgi|dll|exe|nsf|cfm|ttf|bat|pl|asp|ics|rtf)$/i';
 $conf['fast_404_html'] = '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML+RDFa 1.0//EN" "http://www.w3.org/MarkUp/DTD/xhtml-rdfa-1.dtd"><html xmlns="http://www.w3.org/1999/xhtml"><head><title>404 Not Found</title></head><body><h1>Not Found</h1><p>The requested URL "@path" was not found on this server.</p></body></html>';
 $conf['fast_404_string_whitelisting'] = array('robots.txt', 'system/files');
 


### PR DESCRIPTION
This PR allows a site to provide an optional FAST_404_EXTS variable to be able to override the default FAST_404 configuration.  This is useful where sites have specific needs for filetypes that are generally not used anywhere else in GovCMS.

This variable is controlled in PROD via the config_map, and can be set locally via a docker-compose.override.file and setting the variable in .env
```
version: '2.3'

services:

  php:
    environment:
      FAST_404_EXTS: ${FAST_404_EXTS}
```