### PR TITLE
Remove the superfluous drush cc all.

### DIFF
--- a/.docker/images/govcms7/scripts/govcms-deploy
+++ b/.docker/images/govcms7/scripts/govcms-deploy
@@ -40,5 +40,4 @@ fi
 # All valid environments.
 if tables=$(drush sqlq 'show tables;') && [ -n "$tables" ]; then
   drush updb -y
-  drush cc all
 fi


### PR DESCRIPTION
- Updb implicitly clears caches after completion this will prevent an additional drush call.