### PR TITLE
Added an nginx redirect to the default govcms favicon.

### DIFF
--- a/.docker/Dockerfile.nginx-drupal
+++ b/.docker/Dockerfile.nginx-drupal
@@ -5,8 +5,10 @@ FROM ${CLI_IMAGE} as cli
 FROM amazeeio/nginx-drupal:${LAGOON_IMAGE_VERSION}
 
 # nginx config.
-COPY .docker/images/nginx/helpers/ /etc/nginx/helpers/
 COPY .docker/images/nginx/no-robots.sh /lagoon/entrypoints/20-no-robots.sh
+COPY .docker/images/nginx/helpers/ /etc/nginx/helpers/
+COPY .docker/images/nginx/drupal /etc/nginx/conf.d/drupal
+
 RUN fix-permissions /etc/nginx
 
 COPY --from=cli /app /app

--- a/.docker/images/nginx/drupal/favicon.conf
+++ b/.docker/images/nginx/drupal/favicon.conf
@@ -1,4 +1,5 @@
 # Try to find a favicon in the app root otherwise default to govcms' icon.
 location /favicon.ico {
+  expires 30d
   try_files $uri /app/profiles/govcms/themes/govcms/govcms_zen/favicon.ico
 }

--- a/.docker/images/nginx/helpers/230-favicon.conf
+++ b/.docker/images/nginx/helpers/230-favicon.conf
@@ -1,0 +1,4 @@
+# Try to find a favicon in the app root otherwise default to govcms' icon.
+location /favicon.ico {
+  try_files $uri /app/profiles/govcms/themes/govcms/govcms_zen/favicon.ico
+}

--- a/tests/goss/goss.nginx-drupal.yaml
+++ b/tests/goss/goss.nginx-drupal.yaml
@@ -1,3 +1,7 @@
 ---
 gossfile:
   sanitise.yaml: {}
+
+file:
+  /etc/nginx/conf.d/drupal/favicon.conf:
+    exists: true


### PR DESCRIPTION
Adds a nginx config value to redirect /favicon to one provided by the profile if it does not exist. This happens when loading files (PDFs) or server errors as the browser will request /favicon.ico by default.