### PR TITLE
Removed fake cache on production environments.

### DIFF
--- a/.docker/images/govcms7/settings/production.settings.php
+++ b/.docker/images/govcms7/settings/production.settings.php
@@ -6,16 +6,8 @@
  * This file will only be included on production environments.
  */
 
-// Cache settings.
-if (!class_exists('DrupalFakeCache')) {
-  $conf['cache_backends'][] = 'includes/cache-install.inc';
-}
-// Rely on the external cache for page caching.
-$conf['cache_class_cache_page'] = 'DrupalFakeCache';
 $conf['cache'] = 1;
 $conf['page_cache_maximum_age'] = 300;
-// We can't use an external cache if we are trying to invoke these hooks.
-$conf['page_cache_invoke_hooks'] = FALSE;
 
 // Inject Google Analytics snippet on all production sites.
 $conf['googleanalytics_codesnippet_after'] = "ga('create', 'UA-54970022-1', 'auto', {'name': 'govcms'}); ga('govcms.send', 'pageview', {'anonymizeIp': true})";


### PR DESCRIPTION
Fakecache was introduced here:
https://github.com/govCMS/govcmslagoon/commit/612ee853317f48e82253bbcb9b48047a3e7aba72#diff-a24fa32001f04d3c8c807502e2c45385

It appears this was intended on letting CDN caching layers becoming entirely responsible for page caching, but this leads to poor performance for authenticated users.