### PR TITLE
add shared files volume to php image and expose on host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+/files
 .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,7 @@ version: '2.3'
 x-volumes:
   &default-volumes
     volumes:
-      - ./modules:/app/profiles/govcms/modules/migration:${VOLUME_FLAGS:-delegated} ### Removed automatically in CI.
-      - /app/sites/default/files
+      - ./files:/app/sites/default/files:delegated
 
 x-environment:
   &default-environment
@@ -67,6 +66,7 @@ services:
         LAGOON_IMAGE_VERSION: ${LAGOON_IMAGE_VERSION_PHP}
         PHP_IMAGE_VERSION: ${PHP_IMAGE_VERSION:-7.1}
     image: ${DOCKERHUB_NAMESPACE:-govcmslagoon}/php
+    << : *default-volumes
     environment:
       << : *default-environment
 


### PR DESCRIPTION
This PR fixes an issue that without the `*default-volumes` being added into the php image, php effectively created it's own files volume, and didn't share it with NGINX.  In addition, this volume is mounted into the host for visibility whilst testing.

It also removes a legacy migration volume that is no longer needed.

*Note* that these changes only affect development/testing undertaken on the govcmslagoon repo, and have no effect on the downstream images created and consumed by GovCMS sites.