### PR TITLE
Clear caches to reduce image size.

### DIFF
--- a/.docker/Dockerfile.php
+++ b/.docker/Dockerfile.php
@@ -5,11 +5,11 @@ FROM ${CLI_IMAGE} as cli
 
 FROM amazeeio/php:${PHP_IMAGE_VERSION}-fpm${LAGOON_IMAGE_VERSION_PHP}
 
-RUN apk add gmp gmp-dev \
+RUN apk add --no-cache gmp gmp-dev \
     && docker-php-ext-install gmp \
     && docker-php-ext-configure gmp
 
-RUN apk add --update clamav clamav-libunrar \
+RUN apk add --no-cache --update clamav clamav-libunrar \
     && freshclam
 
 COPY --from=cli /app /app

--- a/.docker/Dockerfile.test
+++ b/.docker/Dockerfile.test
@@ -15,6 +15,7 @@ COPY --from=cli /app /app
 RUN cp -r /app/profiles/govcms/tests /app/ \
     && echo "memory_limit=-1" >> /usr/local/etc/php/conf.d/memory.ini \
     && composer install -d /app/tests -n --ansi --prefer-dist --no-suggest \
+    && composer clearcache \
     && drush dl drupalorg_drush-7.x-1.x-dev -y \
     && rm -rf /usr/local/etc/php/conf.d/memory.ini \
     && mv /app/profiles/govcms/.docker/lint-govcms /usr/bin/lint-govcms \


### PR DESCRIPTION
- Clears composer cache after install.
- Installs apk packages without cache.

Using `composer clearcache` as composer could be configured to cache in different locations we use the composer command to clear cache.

@see https://github.com/composer/composer/pull/3175/files