### PR TITLE
Added scheme to default Lagoon Solr server config.

### DIFF
--- a/modules/lagoon/lagoon_search/lagoon_search.module
+++ b/modules/lagoon/lagoon_search/lagoon_search.module
@@ -20,6 +20,7 @@ function lagoon_search_default_search_api_server() {
    "description" : "",
    "class" : "search_api_solr_service",
    "options" : {
+     "scheme" : "http",
      "host" : "' . $host . '",
      "port" : "8983",
      "path" : "' . $path . '",


### PR DESCRIPTION
https://jira.gold.gov.au/jira/browse/GOVCMSD7-209

## Context
Lagoon Search module sets up the default Solr server when it gets enabled but it doesn't specify the "scheme" option as part of the default configuration. This produces a PHP notice when accessing the server settings page.

The scheme option is specified correctly in GovCMS D8: 
https://github.com/govCMS/govcms8lagoon/blob/master/modules/lagoon/lagoon_search/config/install/search_api.server.lagoon_solr.yml#L13 

![Screen Shot 2019-05-04 at 11 15 03 am](https://user-images.githubusercontent.com/167788/63902037-ad931900-ca4a-11e9-9cd0-a921b87c76a4.png)
