### PR TITLE
[GOVCMSD7-282] Improve govcms-deploy script

### DIFF
--- a/.docker/images/govcms7/scripts/govcms-deploy
+++ b/.docker/images/govcms7/scripts/govcms-deploy
@@ -37,14 +37,6 @@ else
 
 fi
 
-# Fix for redirect to be removed after deployment.
-# For more information, see https://github.com/govCMS/govCMS/pull/827
-# Deploying this must accompany the change from the above PR.
-if redirect=$(drush sqlq "SELECT schema_version FROM system WHERE name = 'redirect' AND schema_version = '7101';") && [ -n "${redirect}" ]; then
-  echo "Reverting schema version used by redirect to version 7100 for newer database updates.";
-  drush sql-query "UPDATE system SET schema_version = 7100 WHERE name = 'redirect';";
-fi
-
 # All valid environments.
 if tables=$(drush sqlq 'show tables;') && [ -n "$tables" ]; then
   drush updb -y

--- a/.docker/images/govcms7/scripts/govcms-deploy
+++ b/.docker/images/govcms7/scripts/govcms-deploy
@@ -9,6 +9,7 @@ mkdir -p /app/sites/default/files/private/tmp/
 # Database updates, cache rebuild.
 common_deploy () {
     drush updb -y
+    drush cc all -y
     
     # Non production environments.
     if [[ ! -z "$LAGOON_ENVIRONMENT_TYPE" && "$LAGOON_ENVIRONMENT_TYPE" != "production" ]]; then

--- a/.docker/images/govcms7/scripts/govcms-deploy
+++ b/.docker/images/govcms7/scripts/govcms-deploy
@@ -6,40 +6,38 @@
 # Ensure tmp folder always exists.
 mkdir -p /app/sites/default/files/private/tmp/
 
-# All valid environments.
-if tables=$(drush sqlq 'show tables;') && [ -n "$tables" ]; then
+# Database updates, cache rebuild.
+common_deploy () {
     drush updb -y
-fi
+    
+    # Non production environments.
+    if [[ "$LAGOON_ENVIRONMENT_TYPE" != "production" ]]; then
+        # Enable stage file proxy post db-import.
+        drush en stage_file_proxy -y
+    fi
+}
 
 # Non production environments.
 if [[ "$LAGOON_ENVIRONMENT_TYPE" != "production" ]]; then
     # Import production database on initial deployment (when database is empty).
     if tables=$(drush sqlq 'show tables;') && [ -z "$tables" ]; then
-
         # SQL sync only in Lagoon development environments.
         if [[ ! -z "$LAGOON_ENVIRONMENT_TYPE" && "$LAGOON_ENVIRONMENT_TYPE" != "local" ]]; then
             drush sql-sync @govcms-prod @self -y
-
-            # Update db which is from PROD db sync.
-            drush updb -y
-
-            # Enable stage file proxy post db-import.
-            drush en stage_file_proxy -y
+            common_deploy
+        else
+            echo "Drupal not installed."
         fi
-
     else
-        # Enable stage file proxy.
-        drush en stage_file_proxy -y
+        common_deploy
     fi
-
 # Production environments.
 else
-
     if tables=$(drush sqlq 'show tables;') && [ -n "$tables" ]; then
         mkdir -p /app/sites/default/files/private/backups/ && drush sql-dump --ordered-dump --gzip --result-file=/app/sites/default/files/private/backups/pre-deploy-dump.sql
+        common_deploy
         drush en -y govcms_lagoon && drush dis -y govcms_lagoon; drush pmu -y govcms_lagoon;
     else
         echo "Drupal not installed."
     fi
-
 fi

--- a/.docker/images/govcms7/scripts/govcms-deploy
+++ b/.docker/images/govcms7/scripts/govcms-deploy
@@ -6,38 +6,40 @@
 # Ensure tmp folder always exists.
 mkdir -p /app/sites/default/files/private/tmp/
 
+# All valid environments.
+if tables=$(drush sqlq 'show tables;') && [ -n "$tables" ]; then
+    drush updb -y
+fi
+
 # Non production environments.
 if [[ "$LAGOON_ENVIRONMENT_TYPE" != "production" ]]; then
     # Import production database on initial deployment (when database is empty).
     if tables=$(drush sqlq 'show tables;') && [ -z "$tables" ]; then
-
+        
         # SQL sync only in Lagoon development environments.
         if [[ ! -z "$LAGOON_ENVIRONMENT_TYPE" && "$LAGOON_ENVIRONMENT_TYPE" != "local" ]]; then
-          drush sql-sync @govcms-prod @self -y
-
-          # Enable stage file proxy post db-import.
-          drush en stage_file_proxy -y
+            drush sql-sync @govcms-prod @self -y
+            
+            # Update db which is from PROD db sync.
+            drush updb -y
+            
+            # Enable stage file proxy post db-import.
+            drush en stage_file_proxy -y
         fi
-
+        
     else
-      # Enable stage file proxy.
-      drush en stage_file_proxy -y
+        # Enable stage file proxy.
+        drush en stage_file_proxy -y
     fi
-
-# Production environments.
+    
+    # Production environments.
 else
-
-  if tables=$(drush sqlq 'show tables;') && [ -n "$tables" ]; then
-
-    mkdir -p /app/sites/default/files/private/backups/ && drush sql-dump --ordered-dump --gzip --result-file=/app/sites/default/files/private/backups/pre-deploy-dump.sql
-    drush en -y govcms_lagoon && drush dis -y govcms_lagoon; drush pmu -y govcms_lagoon;
-  else
-    echo "Drupal not installed."
-  fi
-
-fi
-
-# All valid environments.
-if tables=$(drush sqlq 'show tables;') && [ -n "$tables" ]; then
-  drush updb -y
+    
+    if tables=$(drush sqlq 'show tables;') && [ -n "$tables" ]; then
+        mkdir -p /app/sites/default/files/private/backups/ && drush sql-dump --ordered-dump --gzip --result-file=/app/sites/default/files/private/backups/pre-deploy-dump.sql
+        drush en -y govcms_lagoon && drush dis -y govcms_lagoon; drush pmu -y govcms_lagoon;
+    else
+        echo "Drupal not installed."
+    fi
+    
 fi

--- a/.docker/images/govcms7/scripts/govcms-deploy
+++ b/.docker/images/govcms7/scripts/govcms-deploy
@@ -11,7 +11,7 @@ common_deploy () {
     drush updb -y
     
     # Non production environments.
-    if [[ "$LAGOON_ENVIRONMENT_TYPE" != "production" ]]; then
+    if [[ ! -z "$LAGOON_ENVIRONMENT_TYPE" && "$LAGOON_ENVIRONMENT_TYPE" != "production" ]]; then
         # Enable stage file proxy post db-import.
         drush en stage_file_proxy -y
     fi

--- a/.docker/images/govcms7/scripts/govcms-deploy
+++ b/.docker/images/govcms7/scripts/govcms-deploy
@@ -15,31 +15,31 @@ fi
 if [[ "$LAGOON_ENVIRONMENT_TYPE" != "production" ]]; then
     # Import production database on initial deployment (when database is empty).
     if tables=$(drush sqlq 'show tables;') && [ -z "$tables" ]; then
-        
+
         # SQL sync only in Lagoon development environments.
         if [[ ! -z "$LAGOON_ENVIRONMENT_TYPE" && "$LAGOON_ENVIRONMENT_TYPE" != "local" ]]; then
             drush sql-sync @govcms-prod @self -y
-            
+
             # Update db which is from PROD db sync.
             drush updb -y
-            
+
             # Enable stage file proxy post db-import.
             drush en stage_file_proxy -y
         fi
-        
+
     else
         # Enable stage file proxy.
         drush en stage_file_proxy -y
     fi
-    
-    # Production environments.
+
+# Production environments.
 else
-    
+
     if tables=$(drush sqlq 'show tables;') && [ -n "$tables" ]; then
         mkdir -p /app/sites/default/files/private/backups/ && drush sql-dump --ordered-dump --gzip --result-file=/app/sites/default/files/private/backups/pre-deploy-dump.sql
         drush en -y govcms_lagoon && drush dis -y govcms_lagoon; drush pmu -y govcms_lagoon;
     else
         echo "Drupal not installed."
     fi
-    
+
 fi


### PR DESCRIPTION
As discussed, the PR contains the following changes:

- Remove the one-off fix to redirect module legacy issue
- Add a ```drush updb - y``` for PROD db synced across
- Run ```drush updb - y``` before ```drush en stage_file_proxy -y```