### PR TITLE
Update catch for CLAMAV_MODE

### DIFF
--- a/.docker/images/govcms7/settings/settings.php
+++ b/.docker/images/govcms7/settings/settings.php
@@ -188,8 +188,8 @@ $conf['drupal_http_request_fails'] = FALSE;
 
 // ClamAV configuration.
 if (getenv('LAGOON')) {
-  $clam_mode = getenv('CLAMAV_MODE') ?: 1;
-  if ($clam_mode == 0) {
+  $clam_mode = getenv('CLAMAV_MODE') !== FALSE ? getenv('CLAMAV_MODE') : 1;
+  if ($clam_mode == 0 || $clam_mode == 'daemon') {
     $conf['clamav_mode'] = 0;
     $conf['clamav_daemon_host'] = getenv('CLAMAV_HOST') ?: 'localhost';
     $conf['clamav_daemon_port'] = getenv('CLAMAV_PORT') ?: 3310;


### PR DESCRIPTION
'0' was being treated as a falsey always so even with the correct environment variables set it would still use the binary.

- Adds a strict type check for !== false as getenv will return bool if the variable is not defined.
- Adds a looser catch by setting to a string of daemon so we can fallback if '0' is mistreated.