### PR TITLE
Added redis config for port and cache prefix.

### DIFF
--- a/.docker/images/govcms7/settings/settings.php
+++ b/.docker/images/govcms7/settings/settings.php
@@ -147,7 +147,6 @@ if ((getenv('LAGOON')) && (getenv('ENABLE_REDIS'))) {
   if (file_exists("$redis/redis.module")) {
     require_once "$redis/redis.module";
     $conf['redis_client_host'] = getenv('REDIS_HOST') ?: 'redis';
-    $conf['redis_client_host'] = getenv('REDIS_HOST') ?: 'redis';  
     $conf['redis_client_port'] = getenv('REDIS_SERVICE_PORT') ?: 6379;
     $conf['cache_prefix'] = getenv('REDIS_CACHE_PREFIX') ?: getenv('LAGOON_PROJECT') . '_' . getenv('LAGOON_GIT_SAFE_BRANCH');
     try {

--- a/.docker/images/govcms7/settings/settings.php
+++ b/.docker/images/govcms7/settings/settings.php
@@ -144,6 +144,8 @@ if (getenv('LAGOON')) {
 if ((getenv('LAGOON'))  && (getenv('ENABLE_REDIS'))) {
   $conf['redis_client_interface'] = 'PhpRedis';
   $conf['redis_client_host'] = getenv('REDIS_HOST') ?: 'redis';
+  $conf['redis_client_port'] = getenv('REDIS_SERVICE_PORT') ?: 6379;
+  $conf['cache_prefix'] = getenv('REDIS_CACHE_PREFIX') ?: getenv('LAGOON_PROJECT') . '_' . getenv('LAGOON_GIT_SAFE_BRANCH');
   $conf['lock_inc'] = $contrib_path . '/redis/redis.lock.inc';
   $conf['path_inc'] = $contrib_path . '/redis/redis.path.inc';
   $conf['cache_backends'][] = $contrib_path . '/redis/redis.autoload.inc';


### PR DESCRIPTION
Allow overriding of the redis port and cache prefix without affecting current behaviour.

Projects will be able to customise the redis HOST, PORT and CACHE_PREFIX if required.