### PR TITLE
Set max-age header to 1h by default.

### DIFF
--- a/.docker/images/govcms7/settings/production.settings.php
+++ b/.docker/images/govcms7/settings/production.settings.php
@@ -13,7 +13,11 @@ if (!class_exists('DrupalFakeCache')) {
 // Rely on the external cache for page caching.
 $conf['cache_class_cache_page'] = 'DrupalFakeCache';
 $conf['cache'] = 1;
-$conf['page_cache_maximum_age'] = 300;
+$conf['page_cache_maximum_age'] = 3600;
+if (is_numeric($max_age=GETENV('CACHE_MAX_AGE'))) {
+  $conf['page_cache_maximum_age']= $max_age;
+}
+
 // We can't use an external cache if we are trying to invoke these hooks.
 $conf['page_cache_invoke_hooks'] = FALSE;
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ x-environment:
   &default-environment
     LAGOON_ROUTE: ${LOCALDEV_URL:-http://govcmslagoon.docker.amazee.io}
     X_FRAME_OPTIONS: ${X_FRAME_OPTIONS:-SameOrigin}
+    CACHE_MAX_AGE: ${CACHE_MAX_AGE:-3600}
 
 services:
 


### PR DESCRIPTION
Alters default max-age header to 1h with env var override.