### PR TITLE
Rolled back default max-age header to 900s.

### DIFF
--- a/.docker/images/govcms7/scripts/govcms-deploy
+++ b/.docker/images/govcms7/scripts/govcms-deploy
@@ -48,6 +48,7 @@ if [[ ! -z "$LAGOON_ENVIRONMENT_TYPE" && "$LAGOON_ENVIRONMENT_TYPE" != "producti
     if tables=$(drush sqlq 'show tables;') && [ -z "$tables" ]; then
         # SQL sync only in Lagoon development environments.
         if [[ ! -z "$LAGOON_ENVIRONMENT_TYPE" && "$LAGOON_ENVIRONMENT_TYPE" != "local" ]]; then
+            drush sql-drop -y
             drush sql-sync @govcms-prod @self $sync_opts -y
             common_deploy
         else
@@ -57,6 +58,7 @@ if [[ ! -z "$LAGOON_ENVIRONMENT_TYPE" && "$LAGOON_ENVIRONMENT_TYPE" != "producti
         # @see comments for GOVCMS_TEST_CANARY above.
         if [[ "$GOVCMS_TEST_CANARY" = TRUE ]]; then
             echo "GOVCMS_TEST_CANARY is set, syncing the database."
+            drush sql-drop -y
             drush sql-sync @govcms-prod @self $sync_opts -y
         fi
         common_deploy

--- a/.docker/images/govcms7/settings/production.settings.php
+++ b/.docker/images/govcms7/settings/production.settings.php
@@ -13,7 +13,7 @@ if (!class_exists('DrupalFakeCache')) {
 // Rely on the external cache for page caching.
 $conf['cache_class_cache_page'] = 'DrupalFakeCache';
 $conf['cache'] = 1;
-$conf['page_cache_maximum_age'] = 3600;
+$conf['page_cache_maximum_age'] = 900;
 if (is_numeric($max_age=GETENV('CACHE_MAX_AGE'))) {
   $conf['page_cache_maximum_age']= $max_age;
 }


### PR DESCRIPTION
Ensure database drop before sync.