### PR TITLE
Additional requirements for 7.x.3.11

### DIFF
--- a/.docker/Dockerfile.govcms7
+++ b/.docker/Dockerfile.govcms7
@@ -38,9 +38,6 @@ RUN apk add --no-cache python findutils \
     lagoon_logs-7.x-1.0 \
     redis-7.x-3.17 \
     stage_file_proxy-7.x-1.9 \
-    && wget https://www.drupal.org/files/issues/drupal-500_exception_on_exception-12221055-6.patch \
-    && patch -p1 < drupal-500_exception_on_exception-12221055-6.patch \
-    && rm drupal-500_exception_on_exception-12221055-6.patch \
     && mkdir -p /app/sites/default/files/private \
     && fix-permissions /home/.drush \
     && chmod +x /app/sanitize.sh \

--- a/.env.default
+++ b/.env.default
@@ -35,7 +35,7 @@ PHP_IMAGE_VERSION=7.2
 
 # Set the GovCMS version to use - you can use a tag or branch reference here
 # See https://github.com/govCMS/govcms/releases
-GOVCMS_PROJECT_VERSION=7.x-3.10
+GOVCMS_PROJECT_VERSION=release/7.x-3.11
 
 # Set the version of the site audit script to use - you can use a tag or branch reference here
 # See https://github.com/govCMS/audit-site/releases


### PR DESCRIPTION
Updates required for `v7.x-3.11` builds to complete:
* Removal of `https://www.drupal.org/files/issues/drupal-500_exception_on_exception-12221055-6.patch` because of upstream merge in Drupal `7.67`.
* Update version reference