### PR TITLE
[GOVCMS-4396] Add mydumper/myloader.

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -15,16 +15,16 @@ commands:
     cmd: docker-compose up -d --build "$@"
 
   cli:
-    usage: Start a shell inside TEST container.
-    cmd: docker-compose exec test bash
+    usage: Start a shell inside cli container.
+    cmd: docker-compose exec cli bash
 
   run:
-    usage: Run command inside TEST container.
-    cmd: docker-compose exec -T test bash -c "$@"
+    usage: Run command inside cli container.
+    cmd: docker-compose exec -T cli bash -c "$@"
 
   drush:
-    usage: Run drush commands in TEST container.
-    cmd: docker-compose exec -T test drush "$@"
+    usage: Run drush commands in cli container.
+    cmd: docker-compose exec -T cli drush "$@"
 
   logs:
     usage: Show Docker logs.
@@ -44,11 +44,11 @@ commands:
 
   install:
     usage: Install the profile.
-    cmd: docker-compose exec -T test drush si -y govcms "$@"
+    cmd: docker-compose exec -T cli drush si -y govcms "$@"
 
   login:
     usage: Login to a website.
-    cmd: docker-compose exec -T test drush uli "$@"
+    cmd: docker-compose exec -T cli drush uli "$@"
 
   lint:
     usage: Lint code

--- a/.docker/Dockerfile.govcms7
+++ b/.docker/Dockerfile.govcms7
@@ -50,3 +50,24 @@ COPY modules/ /app/sites/all/modules/
 
 COPY .docker/images/govcms7/settings/ /app/sites/default/
 RUN chmod 444 /app/sites/default/settings.php
+
+# Compile mydumper/myloader.
+ENV LIB_PACKAGES="glib-dev mariadb-dev zlib-dev pcre-dev libressl-dev" \
+    BUILD_PACKAGES="cmake build-base git" \
+    BUILD_PATH="/opt/mydumper-src/"
+
+RUN apk --no-cache add \
+          $BUILD_PACKAGES \
+          $LIB_PACKAGES \
+    && \
+    git clone https://github.com/maxbube/mydumper.git $BUILD_PATH && \
+    cd $BUILD_PATH && \
+    cmake . && \
+    make && \
+    mv ./mydumper /usr/bin/. && \
+    mv ./myloader /usr/bin/. && \
+    cd / && rm -rf $BUILD_PATH && \
+    apk del $BUILD_PACKAGES && \
+    rm -f /usr/lib/*.a && \
+    (rm "/tmp/"* 2>/dev/null || true) && \
+    (rm -rf /var/cache/apk/* 2>/dev/null || true)


### PR DESCRIPTION
Adds the `mydumper` and `myloader` binaries.

Image size before: 435MB
Image size after: 570MB

Wiki: https://projects.govcms.gov.au/GovCMS/wiki/-/wikis/MyDumper/MySQL-import-and-export-(mydumper-and-loader)

## mydumper / myloader

The more performant mydumper/myloader tools will shortly become available in govcmslagoon images. This brings vastly superior database import/export speeds to forklifts and common tasks (e.g predeploy backups, nightly db backups).

Dump:
```
mydumper --database=drupal --user=drupal --password=drupal --host=mariadb --outputdir=web/sites/default/files/private/db_18Feb/
```

Import:
```
myloader --database=drupal --user=drupal --password=drupal --host=mariadb --directory=web/sites/default/files/private/db_18Feb/
```

**Note: ** To test this locally you will need to grant additional permissions (not required with RDS).
```
docker-compose exec -T mariadb mysql -uroot -pLag00n -e "GRANT SUPER,RELOAD ON *.* TO 'drupal'@'%'; FLUSH PRIVILEGES;"
```



## Time comparison

Simple time comparison using vanilla GovCMS8 install.

Note this is a baseline, the results would become more pronounced on sites with larger datasets.


### Dump

Via drush sql-dump:
```
cli-drupal:/app$ time drush sql-dump > /tmp/drush.sql

real	0m0.737s
user	0m0.209s
sys	0m0.205s
```

Via mydumper:
```
cli-drupal:/app$ time mydumper --database=drupal --user=drupal --password=drupal --host=mariadb --outputdir=web/sites/default/files/private/db_18Feb/

real	0m0.142s
user	0m0.044s
sys	0m0.136s
```

~5x faster.

### Import
Via drush sqlc:
```
cli-drupal:/app$ time drush sqlc < /tmp/drush.sql

real	0m1.961s
user	0m0.204s
sys	0m0.143s
```

Via myloader:
```
cli-drupal:/app$ time myloader --database=drupal --user=drupal --password=drupal --host=mariadb --directory=web/sites/default/files/private/db_18Feb/

real	0m1.335s
user	0m0.039s
sys	0m0.043s
```

0.68x faster