### PR TITLE
Draft release: 3.12.0

### DIFF
--- a/.docker/Dockerfile.govcms7
+++ b/.docker/Dockerfile.govcms7
@@ -40,6 +40,7 @@ RUN apk add --no-cache python findutils \
     stage_file_proxy-7.x-1.9 \
     && mkdir -p /app/sites/default/files/private \
     && fix-permissions /home/.drush \
+    && fix-permissions /etc/my.cnf.d \
     && chmod +x /app/sanitize.sh \
     && /app/sanitize.sh
 

--- a/.docker/Dockerfile.php
+++ b/.docker/Dockerfile.php
@@ -12,6 +12,8 @@ RUN apk add --no-cache gmp gmp-dev \
 RUN apk add --no-cache --update clamav clamav-libunrar \
     && freshclam
 
+COPY .docker/images/php/00-govcms.ini /usr/local/etc/php/conf.d/
+
 COPY --from=cli /app /app
 
 RUN /app/sanitize.sh \

--- a/.docker/Dockerfile.php
+++ b/.docker/Dockerfile.php
@@ -6,7 +6,7 @@ FROM ${CLI_IMAGE} as cli
 FROM amazeeio/php:${PHP_IMAGE_VERSION}-fpm-${LAGOON_IMAGE_VERSION}
 
 
-RUN apk add --no-cache --update clamav clamav-libunrar \
+RUN apk add --no-cache --update clamav clamav-libunrar --repository http://dl-cdn.alpinelinux.org/alpine/edge/main \
     && freshclam
 
 COPY .docker/images/php/00-govcms.ini /usr/local/etc/php/conf.d/

--- a/.docker/Dockerfile.php
+++ b/.docker/Dockerfile.php
@@ -5,9 +5,6 @@ FROM ${CLI_IMAGE} as cli
 
 FROM amazeeio/php:${PHP_IMAGE_VERSION}-fpm-${LAGOON_IMAGE_VERSION}
 
-RUN apk add --no-cache gmp gmp-dev \
-    && docker-php-ext-install gmp \
-    && docker-php-ext-configure gmp
 
 RUN apk add --no-cache --update clamav clamav-libunrar \
     && freshclam

--- a/.docker/images/govcms7/settings/settings.php
+++ b/.docker/images/govcms7/settings/settings.php
@@ -23,7 +23,7 @@ $contrib_path = 'sites/all/modules/contrib';
 // @see https://github.com/drupal/drupal/blob/7.x/sites/default/default.settings.php#L518
 // @see https://api.drupal.org/api/drupal/includes%21bootstrap.inc/function/drupal_fast_404/7.x
 include_once($contrib_path . '/fast_404/fast_404.inc');
-$conf['fast_404_exts'] = '/^(?!robots)^(?!sites\/default\/files\/private).*\.(?:png|gif|jpe?g|svg|tiff|bmp|raw|webp|docx?|xlsx?|pptx?|swf|flv|cgi|dll|exe|nsf|cfm|ttf|bat|pl|asp|ics|rtf)$/i';
+$conf['fast_404_exts'] = getenv('FAST_404_EXTS') ?: '/^(?!robots)^(?!sites\/default\/files\/private).*\.(?:png|gif|jpe?g|svg|tiff|bmp|raw|webp|docx?|xlsx?|pptx?|swf|flv|cgi|dll|exe|nsf|cfm|ttf|bat|pl|asp|ics|rtf)$/i';
 $conf['fast_404_html'] = '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML+RDFa 1.0//EN" "http://www.w3.org/MarkUp/DTD/xhtml-rdfa-1.dtd"><html xmlns="http://www.w3.org/1999/xhtml"><head><title>404 Not Found</title></head><body><h1>Not Found</h1><p>The requested URL "@path" was not found on this server.</p></body></html>';
 $conf['fast_404_string_whitelisting'] = array('robots.txt', 'system/files');
 

--- a/.docker/images/nginx/drupal/favicon.conf
+++ b/.docker/images/nginx/drupal/favicon.conf
@@ -1,5 +1,5 @@
 # Try to find a favicon in the app root otherwise default to govcms' icon.
 location /favicon.ico {
-  expires 30d
-  try_files $uri /app/profiles/govcms/themes/govcms/govcms_zen/favicon.ico
+  expires 30d;
+  try_files $uri /app/profiles/govcms/themes/govcms/govcms_zen/favicon.ico;
 }

--- a/.docker/images/nginx/helpers/000-client_max_body_size.conf
+++ b/.docker/images/nginx/helpers/000-client_max_body_size.conf
@@ -1,0 +1,3 @@
+# Set the client max body to change streaming behaviour
+# between nginx and php.
+client_max_body_size  256M;

--- a/.docker/images/php/00-govcms.ini
+++ b/.docker/images/php/00-govcms.ini
@@ -1,0 +1,3 @@
+[PHP]
+
+upload_max_filesize=256M

--- a/.env.default
+++ b/.env.default
@@ -31,11 +31,11 @@ DOCKERHUB_NAMESPACE=govcmslagoon
 X_FRAME_OPTIONS=SameOrigin
 
 # Set the PHP version to use for the upstream dockerfiles (currently 7.2 - use 7.3 for testing)
-PHP_IMAGE_VERSION=7.2
+PHP_IMAGE_VERSION=7.3
 
 # Set the GovCMS version to use - you can use a tag or branch reference here
 # See https://github.com/govCMS/govcms/releases
-GOVCMS_PROJECT_VERSION=release/7.x-3.11
+GOVCMS_PROJECT_VERSION=release/7.x-3.12
 
 # Set the version of the site audit script to use - you can use a tag or branch reference here
 # See https://github.com/govCMS/audit-site/releases

--- a/.env.default
+++ b/.env.default
@@ -43,4 +43,4 @@ SITE_AUDIT_VERSION=7.x-3.x
 
 # Set the Lagoon tag to use for the upstream dockerfiles (e.g. v0.22.0) - make sure you change it for both lines
 # See https://github.com/amazeeio/lagoon/releases
-LAGOON_IMAGE_VERSION=v1.1.2
+LAGOON_IMAGE_VERSION=v1.3.1

--- a/tests/goss/goss.nginx-drupal.yaml
+++ b/tests/goss/goss.nginx-drupal.yaml
@@ -2,6 +2,11 @@
 gossfile:
   sanitise.yaml: {}
 
+command:
+  nginx -T | grep client_max_body_size | tail -1:
+    exit-status: 0
+    stdout:
+      - "client_max_body_size  256M;"
 file:
   /etc/nginx/conf.d/drupal/favicon.conf:
     exists: true

--- a/tests/goss/goss.php.yaml
+++ b/tests/goss/goss.php.yaml
@@ -3,6 +3,11 @@ gossfile:
   sanitise.yaml: {}
 
 command:
+  php -r "echo ini_get('upload_max_filesize');":
+    exit-status: 0
+    stdout:
+      - "256M"
+
   which clamscan:
     exit-status: 0
     stdout:


### PR DESCRIPTION
* [GOVCMSD7-310] Reduce maximum file upload to 256MB
* [GOVCMSD7-290] Remove superfluous GMP libraries
* [GOVCMSD7-13] Allow fast 404 overrides per project
* [NO-TICKET] Use latest ClamAV repository (edge)
* [NO-TICKET] Update to latest Lagoon images (1.3.1)
