### PR TITLE
GOVCMSD7-329: Added default security headers.

### DIFF
--- a/.docker/images/nginx/helpers/207-security-headers.conf
+++ b/.docker/images/nginx/helpers/207-security-headers.conf
@@ -1,0 +1,5 @@
+# Add additional security headers to each request served
+# by nginx.
+
+add_header X-XSS-Protection "${X_XSS_PROTECTION:-1; mode=block}";
+add_header X-Content-Type-Options "${X_CONTENT_TYPE_OPTIONS:-nosniff}";

--- a/.docker/images/nginx/tests/src/SecurityHeadersTest.php
+++ b/.docker/images/nginx/tests/src/SecurityHeadersTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace GovCMSTests;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test frame options from the request.
+ */
+class SecurityHeadersTest extends TestCase
+{
+
+  /**
+   * Ensure that the X-XSS-Protection header is present.
+   */
+  public function testXssProtection()
+  {
+    $headers = \get_curl_headers("/");
+    $this->assertEquals('1; mode=block', $headers['X-XSS-Protection']);
+  }
+
+  /**
+   * Ensure taht the X-Content-Type-Options header is prsent.
+   */
+  public function testContentTypeOptions()
+  {
+    $headers = \get_curl_headers("/");
+    $this->assertEquals('nosniff', $headers['X-Content-Type-Options']);
+  }
+}


### PR DESCRIPTION
As per D8: https://github.com/govCMS/govcms8lagoon/pull/129

```
cli-drupal:/app$ curl -I http://nginx:8080/
HTTP/1.1 200 OK
Server: openresty
...
X-XSS-Protection: 1; mode=block
X-Content-Type-Options: nosniff
```