### PR TITLE
Update .env.default

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -30,7 +30,7 @@ DOCKERHUB_NAMESPACE=govcmslagoon
 # See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
 X_FRAME_OPTIONS=SameOrigin
 
-# Set the PHP version to use for the upstream dockerfiles (currently 7.2 - use 7.3 for testing)
+# Set the PHP version to use for the upstream dockerfiles
 PHP_IMAGE_VERSION=7.3
 
 # Set the GovCMS version to use - you can use a tag or branch reference here


### PR DESCRIPTION
Remove outdated comment "(currently 7.2 - use 7.3 for testing)" from `.env.default` since we are with 7.3 already