### PR TITLE
Increased session lifetime to 8h.

### DIFF
--- a/.docker/images/php/00-govcms.ini
+++ b/.docker/images/php/00-govcms.ini
@@ -1,5 +1,5 @@
 [PHP]
 
 session.gc_maxlifetime=3600
-session.cookie_lifetime=3600
+session.cookie_lifetime=28800
 upload_max_filesize=256M


### PR DESCRIPTION
Noting that:
```
session.gc_divisor => 1000 => 1000
session.gc_probability => 1 => 1
```

GC will kick in 0.1% of the time at present, so on average you will need ~1000 hits at origin to trigger a session cleanup.