### PR TITLE
Forced ssl redirects on acsf theme files.

### DIFF
--- a/.docker/images/nginx/helpers/202-acsf_redirects.conf
+++ b/.docker/images/nginx/helpers/202-acsf_redirects.conf
@@ -1,7 +1,10 @@
 ## ACSF Redirects.
 
 # Theme directory.
-rewrite ^\/sites\/g\/files\/net(\d+)\/themes\/site\/(.+)\/(.*)$ /sites/default/themes/custom/$2/$3?acsf_theme_redirect permanent;
+location ~*  ^\/sites\/g\/files\/net(\d+)\/themes\/site\/(.+)\/(.*)$ {
+    expires 180d;
+    return 301 https://$host/sites/default/themes/custom/$2/$3?acsf_theme_redirect;
+}
 
 # Files directory.
 location ~* ^/sites/g/files/net(?:\d+)/f/(.+)$ {

--- a/.env.default
+++ b/.env.default
@@ -43,4 +43,4 @@ SITE_AUDIT_VERSION=7.x-3.x
 
 # Set the Lagoon tag to use for the upstream dockerfiles (e.g. v0.22.0) - make sure you change it for both lines
 # See https://github.com/amazeeio/lagoon/releases
-LAGOON_IMAGE_VERSION=v1.5.0
+LAGOON_IMAGE_VERSION=v1.8.2


### PR DESCRIPTION
Legacy redirects are not enforcing https on the destination.

This updates theme file redirects to match the method used for public files.