### PR TITLE
Release 3.15.2

### DIFF
--- a/.docker/images/nginx/helpers/202-acsf_redirects.conf
+++ b/.docker/images/nginx/helpers/202-acsf_redirects.conf
@@ -1,7 +1,10 @@
 ## ACSF Redirects.
 
 # Theme directory.
-rewrite ^\/sites\/g\/files\/net(\d+)\/themes\/site\/(.+)\/(.*)$ /sites/default/themes/custom/$2/$3?acsf_theme_redirect permanent;
+location ~*  ^\/sites\/g\/files\/net(\d+)\/themes\/site\/(.+)\/(.*)$ {
+    expires 180d;
+    return 301 https://$host/sites/default/themes/custom/$2/$3?acsf_theme_redirect;
+}
 
 # Files directory.
 location ~* ^/sites/g/files/net(?:\d+)/f/(.+)$ {

--- a/.docker/images/nginx/tests/bootstrap.php
+++ b/.docker/images/nginx/tests/bootstrap.php
@@ -40,17 +40,17 @@ function get_curl_headers($path = '/', $opts = NULL) {
   $response = array_map('trim', $response);
 
   foreach ($response as $line) {
-    if (strpos($line, 'HTTP') !== FALSE) {
+    if (strpos($line, 'HTTP') === 0) {
       $part = explode(' ', $line);
       $headers['Status'] = trim($part[1]);
       continue;
     }
 
     $part = explode(':', $line);
+    $key = array_shift($part);
+    $value = implode(':', $part);
 
-    if (count($part) == 2) {
-      $headers[$part[0]] = trim($part[1]);
-    }
+    $headers[$key] = trim($value);
   }
 
   return $headers;

--- a/.docker/images/nginx/tests/src/AcsfRedirectsTest.php
+++ b/.docker/images/nginx/tests/src/AcsfRedirectsTest.php
@@ -42,6 +42,7 @@ class AcsfRedirectsTest extends TestCase {
   public function testRedirectPath($path) {
     $headers = \get_curl_headers($path);
     $this->assertEquals(301, $headers['Status']);
+    $this->assertEquals(preg_match('#^https://#', $headers['Location']), 1);
   }
 
   /**

--- a/.env.default
+++ b/.env.default
@@ -43,4 +43,4 @@ SITE_AUDIT_VERSION=7.x-3.x
 
 # Set the Lagoon tag to use for the upstream dockerfiles (e.g. v0.22.0) - make sure you change it for both lines
 # See https://github.com/amazeeio/lagoon/releases
-LAGOON_IMAGE_VERSION=v1.5.0
+LAGOON_IMAGE_VERSION=v1.8.2


### PR DESCRIPTION
Minor release to address an issue with mixed content warnings in browsers for some GovCMS 7 sites.

## Included in this release

- Fixes an issue with theme files not redirecting to HTTPS causing mixed content warnings in browsers.
- Updates the Lagoon base images to 1.8.2 

## What does this mean?

Sites that utilised the legacy redirect for theme files were sometimes being served over HTTP which caused some browsers to report mixed content warnings and would cause newer browsers to not execute scripts that were served over HTTP. To resolve, all legacy file redirects will be forced to HTTPS.

## Contributors

- @stooit 