### PR TITLE
Add govcms_security as a dependency in govcms_lagoon

### DIFF
--- a/modules/lagoon/govcms_lagoon/govcms_lagoon.info
+++ b/modules/lagoon/govcms_lagoon/govcms_lagoon.info
@@ -8,3 +8,4 @@ dependencies[] = fast_404
 dependencies[] = clamav
 dependencies[] = robotstxt
 dependencies[] = lagoon_logs
+dependencies[] = govcms_security


### PR DESCRIPTION
As part of our forklift process, we run this in order to ensure that certain required module are enabled:

`drush pm-enable -y govcms_lagoon && drush pmu -y govcms_lagoon`

...which results in this:

`The following module(s) will be enabled: govcms_lagoon, redis, fast404, lagoon_logs, environment_indicator`

The govcms_security module should also be enabled as part of this process.