### PR TITLE
Update the base images to reference the latest Lagoon images

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -43,4 +43,4 @@ SITE_AUDIT_VERSION=7.x-3.x
 
 # Set the Lagoon tag to use for the upstream dockerfiles (e.g. 20.12.0)
 # See https://hub.docker.com/r/uselagoon/php/tags
-LAGOON_IMAGE_VERSION=21.2.1
+LAGOON_IMAGE_VERSION=21.3.0

--- a/.env.default
+++ b/.env.default
@@ -43,4 +43,4 @@ SITE_AUDIT_VERSION=7.x-3.x
 
 # Set the Lagoon tag to use for the upstream dockerfiles (e.g. 20.12.0)
 # See https://hub.docker.com/r/uselagoon/php/tags
-LAGOON_IMAGE_VERSION=21.3.0
+LAGOON_IMAGE_VERSION=21.4.0


### PR DESCRIPTION
This change will incorporate

* https://github.com/uselagoon/lagoon-images/releases/tag/21.3.0
* https://github.com/uselagoon/lagoon-images/releases/tag/21.2.2

Which at a high level will update:

* Update Alpine Linux to `3.12.5`
* PHP to version `7.3.27`
* The opt-in ability to use Nginx `rewrite_log`
* Allow `crond` to use a non-root working directory
* Add Nginx map hash configuration