### PR TITLE
Release/3.21

### DIFF
--- a/.docker/images/govcms7/settings/settings.php
+++ b/.docker/images/govcms7/settings/settings.php
@@ -148,7 +148,7 @@ if (getenv('LAGOON')) {
 
   $conf['reverse_proxy'] = TRUE;
   $conf['reverse_proxy_addresses'] = array_merge(explode(',', getenv('VARNISH_HOSTS')), ['varnish']);
-  $conf['varnish_control_terminal'] = implode($varnish_hosts, " ");
+  $conf['varnish_control_terminal'] = implode(" ", $varnish_hosts);
   $conf['varnish_control_key'] = getenv('VARNISH_SECRET') ?: 'lagoon_default_secret';
   $conf['varnish_version'] = 4;
 }

--- a/.env.default
+++ b/.env.default
@@ -35,7 +35,7 @@ PHP_IMAGE_VERSION=7.4
 
 # Set the GovCMS version to use - you can use a tag or branch reference here
 # See https://github.com/govCMS/govcms/releases
-GOVCMS_PROJECT_VERSION=7.x-3.20
+GOVCMS_PROJECT_VERSION=7.x-3.21
 
 # Set the version of the site audit script to use - you can use a tag or branch reference here
 # See https://github.com/govCMS/audit-site/releases

--- a/.env.default
+++ b/.env.default
@@ -31,7 +31,7 @@ DOCKERHUB_NAMESPACE=govcmslagoon
 X_FRAME_OPTIONS=SameOrigin
 
 # Set the PHP version to use for the upstream dockerfiles
-PHP_IMAGE_VERSION=7.3
+PHP_IMAGE_VERSION=7.4
 
 # Set the GovCMS version to use - you can use a tag or branch reference here
 # See https://github.com/govCMS/govcms/releases

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       args:
         GOVCMS_PROJECT_VERSION: ${GOVCMS_PROJECT_VERSION:-7.x-3.x}
         LAGOON_IMAGE_VERSION: ${LAGOON_IMAGE_VERSION:-latest}
-        PHP_IMAGE_VERSION: ${PHP_IMAGE_VERSION:-7.3}
+        PHP_IMAGE_VERSION: ${PHP_IMAGE_VERSION:-7.4}
     image: ${DOCKERHUB_NAMESPACE:-govcmslagoon}/govcms7
     << : *default-volumes
     environment:
@@ -33,7 +33,7 @@ services:
       args:
         CLI_IMAGE: ${DOCKERHUB_NAMESPACE:-govcmslagoon}/govcms7
         LAGOON_IMAGE_VERSION: ${LAGOON_IMAGE_VERSION:-latest}
-        PHP_IMAGE_VERSION: ${PHP_IMAGE_VERSION:-7.3}
+        PHP_IMAGE_VERSION: ${PHP_IMAGE_VERSION:-7.4}
         SITE_AUDIT_VERSION: ${SITE_AUDIT_VERSION:-7.x-3.x}
     image: ${DOCKERHUB_NAMESPACE:-govcmslagoon}/test
     << : *default-volumes
@@ -65,7 +65,7 @@ services:
       args:
         CLI_IMAGE: ${DOCKERHUB_NAMESPACE:-govcmslagoon}/govcms7
         LAGOON_IMAGE_VERSION: ${LAGOON_IMAGE_VERSION:-latest}
-        PHP_IMAGE_VERSION: ${PHP_IMAGE_VERSION:-7.3}
+        PHP_IMAGE_VERSION: ${PHP_IMAGE_VERSION:-7.4}
     image: ${DOCKERHUB_NAMESPACE:-govcmslagoon}/php
     << : *default-volumes
     environment:


### PR DESCRIPTION
## Changes since 3.20.0:

### GovCMS 7 distribution
From 7.x-3.20 to 7.x-3.21

### Base Images
- From PHP 7.3 to PHP 7.4
- Add CSV to binary file extension list. (#171)
- Update the base images to reference the latest Lagoon images (21.4.0) (#176) 