### PR TITLE
[GOVCMSD7-422] update lagoon to 21.7.0 from 21.6.0

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -43,4 +43,4 @@ SITE_AUDIT_VERSION=7.x-3.x
 
 # Set the Lagoon tag to use for the upstream dockerfiles (e.g. 20.12.0)
 # See https://hub.docker.com/r/uselagoon/php/tags
-LAGOON_IMAGE_VERSION=21.6.0
+LAGOON_IMAGE_VERSION=21.7.0


### PR DESCRIPTION
# lagoon-images 21.7.0

## Changes in this release
use true to activate xdebug instead of any string @tobybellwood (#251)
Install Blackfire Agent and Probe within php containers @Schnitzel (#249)
only accept true for $NEWRELIC_ENABLED @Schnitzel (#250)
Fail image build if composer checksum does not match. @marji (#241)
Adds mongodb-tools to toolbox image @bomoko (#247)
Prevent match in between the string @grappler (#202)

Ref: https://github.com/uselagoon/lagoon-images/releases/tag/21.7.0