### PR TITLE
Deploy beta images via CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -118,9 +118,9 @@ deploy:multiarch:
     - docker login -u $DOCKER_USER -p $DOCKER_PASS
     - ahoy publish y
   only:
-    - feature/multiarch-apple-silicon
     - develop
     - master
+    - /^release\//
     - tags
   needs:
   - test:ahoy


### PR DESCRIPTION
- Updates `when` condition to allow deploying multiarch images from `release/*` branches