### PR TITLE
[DEVOPS-190] Improve autodiscover.xml blocking

### DIFF
--- a/.docker/images/nginx/helpers/201-blocks.conf
+++ b/.docker/images/nginx/helpers/201-blocks.conf
@@ -10,7 +10,7 @@ if ($http_user_agent ~* (Skype.for.Business|Microsoft.Office) ) {
 }
 
 # Autodiscover URLs which are pointless.
-location /autodiscover.xml {
+location ~* ^/autodiscover(/autodiscover|/autodiscovery|y)?\.xml$ {
     return 403;
 }
 


### PR DESCRIPTION
1) Improve blocking of autodiscover.xml requests.

Testing:
```
curl -I -X GET http://govcms-lagoon-nginx.docker.amazee.io/autodiscover.xml
HTTP/1.1 403 Forbidden

curl -I -X GET http://govcms-lagoon-nginx.docker.amazee.io/AutoDiscover.xml
HTTP/1.1 403 Forbidden

curl -I -X GET http://govcms-lagoon-nginx.docker.amazee.io/autodiscovery.xml
HTTP/1.1 403 Forbidden

curl -I -X GET http://govcms-lagoon-nginx.docker.amazee.io/Autodiscovery.xml
HTTP/1.1 403 Forbidden

curl -I -X GET http://govcms-lagoon-nginx.docker.amazee.io/AutoDiscovery.xml 
HTTP/1.1 403 Forbidden

curl -I -X GET http://govcms-lagoon-nginx.docker.amazee.io/autodiscover/autodiscover.xml
HTTP/1.1 403 Forbidden

curl -I -X GET http://govcms-lagoon-nginx.docker.amazee.io/AutoDiscover/AutoDiscover.xml
HTTP/1.1 403 Forbidden

curl -I -X GET http://govcms-lagoon-nginx.docker.amazee.io/autodiscover/autodiscovery.xml
HTTP/1.1 403 Forbidden

curl -I -X GET http://govcms-lagoon-nginx.docker.amazee.io/AutoDiscover/AutoDiscovery.xml
HTTP/1.1 403 Forbidden

```